### PR TITLE
16 store aws prices in dynamodb

### DIFF
--- a/microservices/README.md
+++ b/microservices/README.md
@@ -14,3 +14,9 @@ Install the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/l
 6. Deploy the serverless code using CloudFormation: `sam deploy --guided`
 
 To delete all resources, run `sam delete`
+
+# Microservices
+
+## Store
+
+`aws-services.json` is the source of truth for items stored in the DynamoDB table. Whenever that file gets updated, run `python3 populate-dynamodb-table.py` to ensure the DynamoDB table is in sync. This requires having read and write access to the DynamoDB table. boto3 and other dependencies can be installed by running `pip3 install -r requirements.txt`.

--- a/microservices/store/aws-services.json
+++ b/microservices/store/aws-services.json
@@ -1,37 +1,509 @@
-{
-  "AWS-Services": [
-    {
-      "PutRequest": {
-        "Item": {
-          "Id": { "S": "random-uuid" },
-          "Name": { "S": "EC2" },
-          "Description": { "S": "Servers in the cloud" },
-          "Price": { "N": "21" },
-          "Category": { "S": "trial" }
-        }
-      }
-    },
-    {
-      "PutRequest": {
-        "Item": {
-          "Id": { "S": "random-uuid-2" },
-          "Name": { "S": "S3" },
-          "Description": { "S": "Cloud storage" },
-          "Price": { "N": "5" },
-          "Category": { "S": "trial" }
-        }
-      }
-    },
-    {
-      "PutRequest": {
-        "Item": {
-          "Id": { "S": "random-uuid-3" },
-          "Name": { "S": "Lambda" },
-          "Description": { "S": "Run code in under 15 minutes" },
-          "Price": { "N": "1" },
-          "Category": { "S": "free" }
-        }
-      }
-    }
-  ]
-}
+[
+  {
+    "Name": "EC2",
+    "Description": "Servers in the cloud",
+    "Price": 7.2,
+    "Unit": "instance",
+    "Category": "trial"
+  },
+  {
+    "Name": "S3",
+    "Description": "Object-based cloud storage",
+    "Price": 0.02,
+    "Unit": "GB",
+    "Category": "trial"
+  },
+  {
+    "Name": "Lambda",
+    "Description": "Run code in under 15 minutes",
+    "Price": 2e-7,
+    "Unit": "invocation",
+    "Category": "free",
+    "FreeTier": 1e6
+  },
+  {
+    "Name": "Auto Scaling",
+    "Description": "Automatically scale the number of EC2 instances with demand",
+    "Price": 0,
+    "Unit": "group",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "Certificate Manager",
+    "Description": "Provision SSL certificates using Let's Encrypt",
+    "Price": 0,
+    "Unit": "certificate",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "CloudFormation",
+    "Description": "Build infrastructure as code (IaC)",
+    "Price": 0,
+    "Unit": "stack",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "CloudFront",
+    "Description": "Front services across edge locations using HTTPS",
+    "Price": 1e-6,
+    "Unit": "origin request",
+    "Category": "free",
+    "FreeTier": 1e7
+  },
+  {
+    "Name": "CloudTrail",
+    "Description": "Audit all AWS API calls",
+    "Price": 1e-6,
+    "Unit": "event",
+    "Category": "free",
+    "FreeTier": 1e5
+  },
+  {
+    "Name": "CloudWatch",
+    "Description": "Monitor application metrics and set up alarms",
+    "Price": 0.3,
+    "Unit": "metric",
+    "Category": "free",
+    "FreeTier": 10
+  },
+  {
+    "Name": "CodeArtifact",
+    "Description": "Store software and generic packages, Artifactory-like",
+    "Price": 0.05,
+    "Unit": "GB",
+    "Category": "free",
+    "FreeTier": 2
+  },
+  {
+    "Name": "CodeBuild",
+    "Description": "CI (Continuous Integration): build and test your code",
+    "Price": 0.01,
+    "Unit": "build minute",
+    "Category": "free",
+    "FreeTier": 100
+  },
+  {
+    "Name": "CodeCommit",
+    "Description": "Code repository, GitHub-like",
+    "Price": 1,
+    "Unit": "user",
+    "Category": "free",
+    "FreeTier": 5
+  },
+  {
+    "Name": "CodePipeline",
+    "Description": "CI/CD pipeline",
+    "Price": 1,
+    "Unit": "pipeline",
+    "Category": "free",
+    "FreeTier": 1
+  },
+  {
+    "Name": "Cognito",
+    "Description": "Authentication for external users",
+    "Price": 0.01,
+    "Unit": "MAU (monthly active user)",
+    "Category": "free",
+    "FreeTier": 5e4
+  },
+  {
+    "Name": "DynamoDB",
+    "Description": "NoSQL, serverless key-value database",
+    "Price": 0.25,
+    "Unit": "GB",
+    "Category": "free",
+    "FreeTier": 25
+  },
+  {
+    "Name": "Elastic Beanstalk",
+    "Description": "Platform as a Service tool for building applications using EC2, Auto Scaling, ALB, RDS, and more",
+    "Price": 5,
+    "Unit": "application",
+    "Category": "paid"
+  },
+  {
+    "Name": "IAM",
+    "Description": "Users, policies, and roles for securing AWS access",
+    "Price": 0,
+    "Unit": "user",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "KMS",
+    "Description": "Manage cryptographic keys for server-side encryption",
+    "Price": 1,
+    "Unit": "customer key",
+    "Category": "paid"
+  },
+  {
+    "Name": "SES",
+    "Description": "Send marketing emails",
+    "Price": 1e-4,
+    "Unit": "email",
+    "Category": "free",
+    "FreeTier": 62e3
+  },
+  {
+    "Name": "Shield",
+    "Description": "Protect against DDoS attacks",
+    "Price": 3e3,
+    "Unit": "advanced subscription",
+    "Category": "paid"
+  },
+  {
+    "Name": "SNS",
+    "Description": "Push notifications to email, SMS, SQS, etc.",
+    "Price": 5e-7,
+    "Unit": "publish",
+    "Category": "free",
+    "FreeTier": 1e6
+  },
+  {
+    "Name": "SQS",
+    "Description": "Poll messages to decouple services",
+    "Price": 4e-7,
+    "Unit": "standard request",
+    "Category": "free",
+    "FreeTier": 1e6
+  },
+  {
+    "Name": "Step Functions",
+    "Description": "Serverless state machines",
+    "Price": 3e-5,
+    "Unit": "state transition",
+    "Category": "free",
+    "FreeTier": 4e3
+  },
+  {
+    "Name": "Systems Manager Parameter Store",
+    "Description": "Key-value store for parameters and secrets",
+    "Price": 0,
+    "Unit": "standard parameter",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "Systems Manager AppConfig",
+    "Description": "Key-value pairs to configure applications",
+    "Price": 2e-7,
+    "Unit": "config request",
+    "Category": "paid"
+  },
+  {
+    "Name": "Systems Manager Automation",
+    "Description": "Runbooks to automate IT operations",
+    "Price": 0.002,
+    "Unit": "step",
+    "Category": "free",
+    "FreeTier": 1e5
+  },
+  {
+    "Name": "Well-Architected Tool",
+    "Description": "Run an analysis of your cloud architecture",
+    "Price": 0,
+    "Unit": "workload",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "X-Ray",
+    "Description": "Debug applications",
+    "Price": 5e-6,
+    "Unit": "trace",
+    "Category": "free",
+    "FreeTier": 1e5
+  },
+  {
+    "Name": "API Gateway",
+    "Description": "Protect APIs at scale",
+    "Price": 1e-6,
+    "Unit": "HTTP API call, Apigee-like",
+    "Category": "trial"
+  },
+  {
+    "Name": "AppSync",
+    "Description": "Create GraphQL APIs",
+    "Price": 4e-6,
+    "Unit": "query",
+    "Category": "trial"
+  },
+  {
+    "Name": "EBS",
+    "Description": "Persistent block storage",
+    "Price": 0.08,
+    "Unit": "GB",
+    "Category": "trial"
+  },
+  {
+    "Name": "ECR",
+    "Description": "Repository for Docker images, Docker Hub-like",
+    "Price": 0.1,
+    "Unit": "public GB",
+    "Category": "free",
+    "FreeTier": 50
+  },
+  {
+    "Name": "ElastiCache",
+    "Description": "Cache data",
+    "Price": 14.4,
+    "Unit": "node",
+    "Category": "trial"
+  },
+  {
+    "Name": "ELB",
+    "Description": "Load balancer",
+    "Price": 14.4,
+    "Unit": "application load balancer (ALB)",
+    "Category": "trial"
+  },
+  {
+    "Name": "IoT Core",
+    "Description": "Connect IoT devices in the cloud",
+    "Price": 1e-6,
+    "Unit": "message",
+    "Category": "trial"
+  },
+  {
+    "Name": "IoT Greengrass",
+    "Description": "Edge runtime for IoT software",
+    "Price": 0.16,
+    "Unit": "device",
+    "Category": "trial"
+  },
+  {
+    "Name": "OpenSearch Service",
+    "Description": "Search logs and applications",
+    "Price": 28.8,
+    "Unit": "instance",
+    "Category": "trial"
+  },
+  {
+    "Name": "Pinpoint",
+    "Description": "Send targeted notifications to users, Airship-like",
+    "Price": 1e-3,
+    "Unit": "user endpoint",
+    "Category": "trial"
+  },
+  {
+    "Name": "RDS",
+    "Description": "Relational database",
+    "Price": 14.4,
+    "Unit": "instance",
+    "Category": "trial"
+  },
+  {
+    "Name": "DeepRacer",
+    "Description": "Compete in an autonomous race using reinforcement learning",
+    "Price": 3.5,
+    "Unit": "training hour",
+    "Category": "trial"
+  },
+  {
+    "Name": "Detective",
+    "Description": "Use ML to identify the root cause of suspicious activity",
+    "Price": 2,
+    "Unit": "GB",
+    "Category": "trial"
+  },
+  {
+    "Name": "Device Farm",
+    "Description": "Test web and mobile apps on real devices hosted in the cloud, Sauce Labs-like",
+    "Price": 0.17,
+    "Unit": "device minute",
+    "Category": "trial"
+  },
+  {
+    "Name": "DocumentDB",
+    "Description": "MongoDB service for document databases",
+    "Price": 57.6,
+    "Unit": "instance",
+    "Category": "trial"
+  },
+  {
+    "Name": "GuardDuty",
+    "Description": "Use ML to detect unusual network activity",
+    "Price": 4e-6,
+    "Unit": "CloudTrail management event analysis",
+    "Category": "trial"
+  },
+  {
+    "Name": "Inspector",
+    "Description": "Detect software vulnerabilities, Dependabot-like",
+    "Price": 0.3,
+    "Unit": "Lambda function",
+    "Category": "trial"
+  },
+  {
+    "Name": "LightSail",
+    "Description": "Quickly create servers",
+    "Price": 3.5,
+    "Unit": "Linux server",
+    "Category": "trial"
+  },
+  {
+    "Name": "Location Service",
+    "Description": "Location data for applications",
+    "Price": 3.5e-5,
+    "Unit": "open map tile",
+    "Category": "trial"
+  },
+  {
+    "Name": "Macie",
+    "Description": "Detect PII (personal identifiable information) in S3",
+    "Price": 0.1,
+    "Unit": "bucket",
+    "Category": "trial"
+  },
+  {
+    "Name": "Redshift",
+    "Description": "Data warehouse",
+    "Price": 180,
+    "Unit": "instance",
+    "Category": "trial"
+  },
+  {
+    "Name": "SageMaker",
+    "Description": "Train and test ML models",
+    "Price": 0.05,
+    "Unit": "notebook hour",
+    "Category": "trial"
+  },
+  {
+    "Name": "Secrets Manager",
+    "Description": "Protect and automatically rotate secrets",
+    "Price": 0.4,
+    "Unit": "secret",
+    "Category": "trial"
+  },
+  {
+    "Name": "App Runner",
+    "Description": "Quickly build and deploy containerized applications",
+    "Price": 5.21,
+    "Unit": "application",
+    "Category": "paid"
+  },
+  {
+    "Name": "Athena",
+    "Description": "Query data in S3 using SQL",
+    "Price": 5e-3,
+    "Unit": "GB",
+    "Category": "paid"
+  },
+  {
+    "Name": "Aurora",
+    "Description": "AWS-managed relational database",
+    "Price": 28.8,
+    "Unit": "instance",
+    "Category": "paid"
+  },
+  {
+    "Name": "Cloud9",
+    "Description": "Cloud IDE",
+    "Price": 7.2,
+    "Unit": "EC2 instance",
+    "Category": "paid"
+  },
+  {
+    "Name": "CloudHSM",
+    "Description": "Dedicated hardware for encryption",
+    "Price": 1152,
+    "Unit": "hardware instance",
+    "Category": "paid"
+  },
+  {
+    "Name": "CodeDeploy",
+    "Description": "CD (continuous delivery): deploy code to EC2, Lambda, and ECS",
+    "Price": 0,
+    "Unit": "deployment",
+    "Category": "free",
+    "FreeTier": null
+  },
+  {
+    "Name": "CodeGuru",
+    "Description": "Automated code review, SonarQube-like",
+    "Price": 10,
+    "Unit": "repo",
+    "Category": "paid"
+  },
+  {
+    "Name": "CodeStar",
+    "Description": "GUI for managing software deployment projects",
+    "Price": 7.2,
+    "Unit": "EC2 instance",
+    "Category": "paid"
+  },
+  {
+    "Name": "Compute Optimizer",
+    "Description": "Provide recommendations to optimize EC2, EBS, ECS, and Lambda usage",
+    "Price": 0.25,
+    "Unit": "resource",
+    "Category": "paid"
+  },
+  {
+    "Name": "Config",
+    "Description": "Audit the configuration of AWS resources",
+    "Price": 0.003,
+    "Unit": "configuration item",
+    "Category": "paid"
+  },
+  {
+    "Name": "ECS",
+    "Description": "Run containers in the cloud",
+    "Price": 21.6,
+    "Unit": "ARM Linux instance",
+    "Category": "paid"
+  },
+  {
+    "Name": "EKS",
+    "Description": "Run Kubernetes in AWS",
+    "Price": 72,
+    "Unit": "cluster",
+    "Category": "paid"
+  },
+  {
+    "Name": "EventBridge",
+    "Description": "Serverless event bus",
+    "Price": 1e-6,
+    "Unit": "custom event",
+    "Category": "paid"
+  },
+  {
+    "Name": "Kinesis",
+    "Description": "Stream data in real-time",
+    "Price": 28.8,
+    "Unit": "data stream",
+    "Category": "paid"
+  },
+  {
+    "Name": "Route 53",
+    "Description": "DNS service for naming websites",
+    "Price": 1.58,
+    "Unit": "hosted zone & .com domain name",
+    "Category": "paid"
+  },
+  {
+    "Name": "Trusted Advisor",
+    "Description": "Cost optimization, performance, security, fault tolerance, and service limit recommendations",
+    "Price": 100,
+    "Unit": "business account",
+    "Category": "paid"
+  },
+  {
+    "Name": "VPC",
+    "Description": "Isolate cloud resources in a virtual network",
+    "Price": 36,
+    "Unit": "NAT gateway",
+    "Category": "paid"
+  },
+  {
+    "Name": "WAF",
+    "Description": "Securely protect web applications using a firewall",
+    "Price": 6,
+    "Unit": "web ACL & rule",
+    "Category": "paid"
+  }
+]

--- a/microservices/store/aws-services.json
+++ b/microservices/store/aws-services.json
@@ -119,7 +119,7 @@
   },
   {
     "Name": "Elastic Beanstalk",
-    "Description": "Platform as a Service tool for building applications using EC2, Auto Scaling, ALB, RDS, and more",
+    "Description": "Platform as a Service (PaaS) tool for building applications using EC2, Auto Scaling, ALB, RDS, and more",
     "Price": 5,
     "Unit": "application",
     "Category": "paid"

--- a/microservices/store/populate-dynamodb-table.py
+++ b/microservices/store/populate-dynamodb-table.py
@@ -1,0 +1,15 @@
+# So here me out:
+# We can create a regular JSON file with the items we want to include.
+# Then using boto3, we can apply a UUID to each item and split the items into chunks of 25 to make
+# batch-write-item happy. (And apply other formatting required for that command.)
+# This would normally be done by a DBA, but we'll use the admin account for now.
+# That is the create part. But we also need to handle upserts and deletions.
+# So we could query the database to see if the service exists.
+# If it does, check if there's a difference between your local JSON and what's stored in the database
+# (minus the UUID).
+# If it doesn't, insert the item into the database like earlier.
+# Good, creation and upserts are taken care of, but what about deletions?
+# I'm sort of handling this like Git for databases.
+# Maybe get all the items in the database and keep track of which items you queried.
+# Every item already present will be queried, so items that were never queried must have been deleted.
+# So remove those items at the end. Maybe with a prompt?

--- a/microservices/store/populate-dynamodb-table.py
+++ b/microservices/store/populate-dynamodb-table.py
@@ -69,7 +69,6 @@ def add_services(local_services, services_to_create):
 def is_equal(local_service, remote_service):
     """Compare all the properties in each service to see if they're the same"""
     keys_to_update = []
-    keys_to_delete = []
 
     # All keys that are only defined locally or differ should be updated
     for key, value in local_service.items():

--- a/microservices/store/populate-dynamodb-table.py
+++ b/microservices/store/populate-dynamodb-table.py
@@ -6,20 +6,40 @@
 import boto3
 from botocore.exceptions import ClientError
 import json
+from math import ceil
 from uuid import uuid4
 
+TABLE_NAME = "AWS-Services"
+JSON_FILE_NAME = "aws-services.json"
+BATCH_WRITE_LIMIT = 25
 
-def main():
-    # Read all the AWS services
-    with open("aws-services.json", "r") as aws_services_file:
-        aws_services = json.load(aws_services_file)
 
+def get_json_file():
+    """Parse the AWS services from the JSON file"""
+    with open(JSON_FILE_NAME, "r") as aws_services_file:
+        return json.load(aws_services_file)
+
+
+def get_all_services(client):
+    """Get all the AWS services currently in the DynamoDB table"""
+    scan_response = client.scan(
+        TableName=TABLE_NAME,
+        ReturnConsumedCapacity="INDEXES",
+    )
+    print(f"{scan_response=}")
+    return scan_response["Items"]
+
+
+def add_services(client, local_services, services_to_create):
+    """Add all AWS services present in the JSON file, but not in DynamoDB"""
     # Transform the JSON file to a supported format for the batch-write-item API
-    TABLE_NAME = "AWS-Services"
-    request_items = {TABLE_NAME: []}
+    put_requests = []
+    filtered_services = [
+        service for service in local_services if service["Name"] in services_to_create
+    ]
 
     # Add a random UUID to each item as the partition key
-    for service in aws_services:
+    for service in filtered_services:
         service["Id"] = str(uuid4())
         service_with_types = {}
 
@@ -33,21 +53,56 @@ def main():
             else:
                 service_with_types[key] = {"N": str(value)}
 
-        request_items[TABLE_NAME].append({"PutRequest": {"Item": service_with_types}})
+        put_requests.append({"PutRequest": {"Item": service_with_types}})
 
     # Write items to a DynamoDB table
-    dynamodb_client = boto3.client("dynamodb")
+    # Split request items into chunks to satisfy batch-write-item's constraint
+    num_chunks = ceil(len(put_requests) / BATCH_WRITE_LIMIT)
+    print(f"Splitting batch-write-item into {num_chunks} chunk(s)")
 
-    # Split request items into chunks of 25 to satisfy batch-write-item's constraint
-    try:
-        batch_write_response = dynamodb_client.batch_write_item(
-            RequestItems=request_items,
-            ReturnConsumedCapacity="INDEXES",
-            ReturnItemCollectionMetrics="SIZE",
-        )
-        print(f"Success!\n{batch_write_response}")
-    except ClientError as error:
-        print(f"Client error: {error}")
+    for chunk_i in range(num_chunks):
+        put_request_chunk = put_requests[
+            (chunk_i * BATCH_WRITE_LIMIT) : ((chunk_i + 1) * BATCH_WRITE_LIMIT)
+        ]
+        request_items = {TABLE_NAME: put_request_chunk}
+
+        try:
+            batch_write_response = client.batch_write_item(
+                RequestItems=request_items,
+                ReturnConsumedCapacity="INDEXES",
+                ReturnItemCollectionMetrics="SIZE",
+            )
+            print(f"Success!\n{batch_write_response}")
+        except ClientError as error:
+            print(f"Client error: {error}")
+
+
+def update_services(client):
+    """Update all AWS services changed in the JSON file"""
+    pass
+
+
+def remove_services(client, remote_services):
+    """Remove all AWS services present in DynamoDB, but no longer present in the JSON file"""
+    pass
+
+
+def main():
+    # Get all the AWS services present in the JSON file and DynamoDB
+    local_services = get_json_file()
+    dynamodb_client = boto3.client("dynamodb")
+    remote_services = get_all_services(dynamodb_client)
+
+    # Create two sets of service names and compare which are only present locally/remotely
+    local_services_set = {service["Name"] for service in local_services}
+    remote_services_set = {service["Name"]["S"] for service in remote_services}
+    services_to_create = local_services_set - remote_services_set
+    services_to_delete = remote_services_set - local_services_set
+
+    # Perform all the create, update, and delete operations
+    add_services(dynamodb_client, local_services, services_to_create)
+    update_services(dynamodb_client)
+    remove_services(dynamodb_client, services_to_delete)
 
 
 if __name__ == "__main__":

--- a/microservices/store/populate-dynamodb-table.py
+++ b/microservices/store/populate-dynamodb-table.py
@@ -35,7 +35,11 @@ def get_all_services(client) -> list[RemoteService] | None:
             TableName=TABLE_NAME,
             ReturnConsumedCapacity="INDEXES",
         )
-        print(f"{scan_response=}")
+        num_items = scan_response["ScannedCount"]
+        read_capacity_units = scan_response["ConsumedCapacity"]["CapacityUnits"]
+        print(
+            f"Successfully scanned {num_items} items and used {read_capacity_units} read capacity units (RCU)"
+        )
         return scan_response["Items"]
     except ClientError as error:
         print(f"scan client error: {error}")
@@ -77,7 +81,7 @@ def add_services(
             }
         )
 
-    print(f"Adding the following services: {put_requests}")
+    print(f"Adding the following services: {services_to_create}")
     return put_requests
 
 
@@ -204,7 +208,8 @@ def update_services(
             }
         )
 
-    print(f"Updating the following services: {update_requests}")
+    updated_services = [service["Name"] for service in filtered_services]
+    print(f"Updating the following services: {updated_services}")
     return update_requests
 
 
@@ -231,7 +236,7 @@ def remove_services(
             }
         )
 
-    print(f"Deleting the following services: {delete_requests}")
+    print(f"Deleting the following services: {services_to_delete}")
     return delete_requests
 
 
@@ -258,7 +263,8 @@ def perform_transaction(
                 ReturnConsumedCapacity="INDEXES",
                 ReturnItemCollectionMetrics="SIZE",
             )
-            print(f"Success!\n{transact_write_response}")
+            print(f"{json.dumps(transact_write_response, indent=4)}")
+            print(f"Success!")
         except ClientError as error:
             print(f"transact-write-items client error: {error}")
 

--- a/microservices/store/populate-dynamodb-table.py
+++ b/microservices/store/populate-dynamodb-table.py
@@ -68,7 +68,6 @@ def add_services(local_services, services_to_create):
 
 def is_equal(local_service, remote_service):
     """Compare all the properties in each service to see if they're the same"""
-    res = True
     keys_to_update = []
     keys_to_delete = []
 
@@ -76,23 +75,20 @@ def is_equal(local_service, remote_service):
     for key, value in local_service.items():
         # Avoid referencing nonexistent keys
         if key not in remote_service:
-            res = False
             keys_to_update.append(key)
         elif value is None and remote_service[key] != {"NULL": True}:
-            res = False
             keys_to_update.append(key)
         elif type(value) is str and remote_service[key] != {"S": value}:
-            res = False
             keys_to_update.append(key)
         elif remote_service[key] != {"N": str(value)}:
-            res = False
             keys_to_update.append(key)
 
     # All keys that are only defined in DynamoDB should be deleted (except the ID field)
     keys_to_delete = [
         key for key in remote_service if key not in local_service and key != "Id"
     ]
-    return res, keys_to_update, keys_to_delete
+    is_eq = not (keys_to_update or keys_to_delete)
+    return is_eq, keys_to_update, keys_to_delete
 
 
 def create_update_expression(local_service, keys_to_update, keys_to_delete):

--- a/microservices/store/populate-dynamodb-table.py
+++ b/microservices/store/populate-dynamodb-table.py
@@ -3,6 +3,55 @@
 # Then using boto3, we can apply a UUID to each item and split the items into chunks of 25 to make
 # batch-write-item happy. (And apply other formatting required for that command.)
 # This would normally be done by a DBA, but we'll use the admin account for now.
+import boto3
+from botocore.exceptions import ClientError
+import json
+from uuid import uuid4
+
+
+def main():
+    # Read all the AWS services
+    with open("aws-services.json", "r") as aws_services_file:
+        aws_services = json.load(aws_services_file)
+
+    # Transform the JSON file to a supported format for the batch-write-item API
+    TABLE_NAME = "AWS-Services"
+    request_items = {TABLE_NAME: []}
+
+    # Add a random UUID to each item as the partition key
+    for service in aws_services:
+        service["Id"] = str(uuid4())
+        service_with_types = {}
+
+        for key, value in service.items():
+            # Set the type of each service property, according to:
+            # https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html
+            if value is None:
+                service_with_types[key] = {"NULL": True}
+            elif type(value) is str:
+                service_with_types[key] = {"S": value}
+            else:
+                service_with_types[key] = {"N": str(value)}
+
+        request_items[TABLE_NAME].append({"PutRequest": {"Item": service_with_types}})
+
+    # Write items to a DynamoDB table
+    dynamodb_client = boto3.client("dynamodb")
+
+    # Split request items into chunks of 25 to satisfy batch-write-item's constraint
+    try:
+        batch_write_response = dynamodb_client.batch_write_item(
+            RequestItems=request_items,
+            ReturnConsumedCapacity="INDEXES",
+            ReturnItemCollectionMetrics="SIZE",
+        )
+        print(f"Success!\n{batch_write_response}")
+    except ClientError as error:
+        print(f"Client error: {error}")
+
+
+if __name__ == "__main__":
+    main()
 # That is the create part. But we also need to handle upserts and deletions.
 # So we could query the database to see if the service exists.
 # If it does, check if there's a difference between your local JSON and what's stored in the database

--- a/microservices/store/requirements.txt
+++ b/microservices/store/requirements.txt
@@ -1,0 +1,7 @@
+boto3==1.26.151
+botocore==1.29.151
+jmespath==1.0.1
+python-dateutil==2.8.2
+s3transfer==0.6.1
+six==1.16.0
+urllib3==1.26.16

--- a/microservices/store/src/app.py
+++ b/microservices/store/src/app.py
@@ -1,9 +1,8 @@
 import json
 import boto3
 
-dynamodb = boto3.resource("dynamodb")
+dynamodb = boto3.client("dynamodb")
 table_name = "AWS-Services"
-table = dynamodb.Table(table_name)
 
 
 def print_context(context):
@@ -56,7 +55,7 @@ def handler(event, context):
         #     )
         #     body = f"Put item {request_json['id']}"
         if route_key == "GET /":
-            response = table.scan()
+            response = dynamodb.scan(TableName=table_name)
             print(f"{response=}")
             body = response["Items"]
         else:

--- a/microservices/store/tests/integration/test_api_gateway.py
+++ b/microservices/store/tests/integration/test_api_gateway.py
@@ -46,6 +46,7 @@ class TestApiGateway:
     def test_api_gateway(self, api_gateway_url):
         """Call the API Gateway endpoint and check the response"""
         response = requests.get(api_gateway_url)
+        json = response.json()
 
         assert response.status_code == 200
-        assert response.json() == []
+        assert type(json) is list and len(json) > 0

--- a/microservices/store/tests/unit/test_handler.py
+++ b/microservices/store/tests/unit/test_handler.py
@@ -27,4 +27,4 @@ def test_lambda_handler(apigw_event):
     assert lambda_response["headers"] == {
         "Content-Type": "application/json",
     }
-    assert body == []
+    assert type(body) is list and len(body) > 0


### PR DESCRIPTION
# Problem

The DynamoDB table was created previously using SAM, but nothing was populated. I could add items using the management console, but I'd rather do everything as code. The CLI has APIs, such as `batch-write-item` and `transact-write-items`, but they require JSON files to be formatted a certain way, and would be hard to maintain.

# Solution

I created a Python script to help with creating, updating, and deleting items from the AWS-Services table. The idea is that a local JSON file would serve as the source of truth for the DynamoDB table. If an item was defined locally, but not in DynamoDB, the script would detect that and make the appropriate API call to add/update the item in DynamoDB. Likewise, if I delete an item from the JSON file that was previously added to DynamoDB, the script would remove the item from the table.

The Python script performs the following steps:

1. Read the local JSON file.
2. Perform a scan to get all items from DynamoDB.
3. Compare which services are only present locally, remotely, and are common.
4. For the items that need to be added:
    1. Generate a random UUID for each item.
    2. Set the types for each value (i.e., S, N, or NULL).
5. For the items that need to be updated:
    1. Check which properties differ between each service item.
    2. Create an update expression consisting of keys to SET (new keys or changes to existing keys) and REMOVE (keys no longer in the JSON file).
    3. Combine the primary key (explained below), update expression, and any attributes defined in the update expression.
7. For the items that need to be deleted:
    1. Get the primary key of each item. In our case, the primary key is a combination of the partition key (Id) and the sort key (Name).
9. Combine all the different transactions into one `transact-write-items` API call. I originally considered using `batch-write-item`, but this command can handle updates and has a limit of 100 items, compared to 25 for the batch command.

# Test Plan

After running `python3 populate-dynamodb-table.py`, I was able to see which items were created, updated, and deleted, as well as how much RCU/WCU they consumed. I made sure to test cases where I add items, remove items, and modify each of the keys.

On the management console, I can see 69 items (unintentional 😏). The total size is 12 KB, so if I'm doing the math right based on my developer associate exam, an eventually consistent read of the entire table would consume 2 RCU. Since 1 RCU = 2 eventually consistent reads of up to 4 KB per second, 2 reads of 4 KB = 8 KB. So, 2 RCU = 16 KB/sec of reads. Writing all this data would take up 12 WCU since 1 WCU = 1 KB/sec. (This doesn't include any GSIs.) To make sure I'm within the free tier, I need to stay within 8K WRU or 40K RRU per month.

<img width="409" alt="image" src="https://github.com/Abhiek187/aws-shop/assets/29958092/2f3f71de-63b7-4398-9a8b-6a73f9c49bd4">

I then tested the API we created earlier: `GET https://vz5vk4kkvh.execute-api.us-east-1.amazonaws.com/`. After making a small modification to the Lambda function, I was able to get all the AWS services from the DynamoDB table. So, this is now ready to be consumed by the React app.