### PR TITLE
Create a stack to subscribe to AWS Health alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Download the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-
 Create stack:
 
 ```bash
-aws cloudformation create-stack --stack-name NAME --template-body FILE_PATH --parameters ParameterKey=KEY,ParameterValue=VALUE
+aws cloudformation create-stack --stack-name NAME --template-body FILE_PATH --parameters ParameterKey=KEY,ParameterValue=VALUE --capabilities CAPABILITY_NAMED_IAM
 ```
 
 List stacks:

--- a/microservices/health-alerts/template.yaml
+++ b/microservices/health-alerts/template.yaml
@@ -1,0 +1,61 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Subscribe to account-specific and global events from AWS Health
+Parameters:
+  Email:
+    Type: String
+    Description: The email address that will receive SNS notifications for the health alerts
+    # Simple regex from https://stackoverflow.com/a/201378
+    AllowedPattern: "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+Resources:
+  EventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: USEast1HealthRule
+      Description: Push AWS Health notifications to an SNS topic
+      EventPattern:
+        source:
+          - aws.health
+        detail-type:
+          - AWS Health Event
+        detail:
+          service:
+            # Services to get notified for health alerts
+            - CLOUDFORMATION
+            - S3
+            - CLOUDFRONT
+            - APIGATEWAY
+            - LAMBDA
+            - DYNAMODB
+            - CODEBUILD
+            - CODEPIPELINE
+            - SQS
+            - COGNITO
+            - CLOUDWATCH
+            - XRAY
+      State: ENABLED
+      Targets:
+        - Id: EmailTarget
+          Arn: !Ref SNSTopic
+  SNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      # Encrypt using the default SNS SSE key
+      # Key aliases: aws kms list-aliases
+      KmsMasterKeyId: alias/aws/sns
+      Subscription:
+        - Endpoint: !Ref Email
+          Protocol: email
+      TopicName: AWSHealthNotifications
+  SNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          # Allow EventBridge to send email alerts using SNS
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref SNSTopic
+      Topics:
+        - !Ref SNSTopic


### PR DESCRIPTION
This stack will subscribe to notifications sent by AWS Health. This is useful if there are any health issues with any of the services I work with in AWS.

I followed the steps in https://docs.aws.amazon.com/health/latest/ug/cloudwatch-events-health.html#creating-event-bridge-events-rule-for-aws-health to create the CloudFormation stack, with help from https://serverlessland.com/patterns/eventbridge-sns?ref=search.