### PR TITLE
Update to Node 18 & switch to an ARM container

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ aws cloudformation describe-stack-resource-drifts --stack-name NAME --stack-reso
 Create change set:
 
 ```bash
-aws cloudformation create-change-set --stack-name NAME --change-set-name CHANGE_SET --template-body FILE_PATH --capabilities CAPABILITY_IAM
+aws cloudformation create-change-set --stack-name NAME --change-set-name CHANGE_SET --template-body FILE_PATH --capabilities CAPABILITY_NAMED_IAM
 ```
 
 List change sets:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 16
+      nodejs: 18
   pre_build:
     commands:
       - cd shop-app # the shell instance is saved every build command

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -96,8 +96,8 @@ Resources:
       Environment:
         # Make sure the image supports the runtime in the buildspec:
         # https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html
-        Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0 # Amazon Linux 2 x86_64 image
+        Type: ARM_CONTAINER
+        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0 # Amazon Linux 2 ARM image
         ComputeType: BUILD_GENERAL1_SMALL # free tier eligible
         EnvironmentVariables:
           - Name: CI


### PR DESCRIPTION
Docker isn't necessary since we just need to upload the React code to S3. But if we were deploying a server somewhere like ECS or EKS, having a Dockerfile would still be useful. Here's a guide for reference: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html

For this PR, I just updated the Node runtime to 18 and switched to an ARM container since it's cheaper.