### PR TITLE
41 monitor trusted advisor checks using eventbridge

### DIFF
--- a/.github/workflows/cfn-info.json
+++ b/.github/workflows/cfn-info.json
@@ -1,0 +1,14 @@
+[
+  {
+    "file": "cloudformation.yaml",
+    "stack": "AWS-Shop-Frontend-Stack"
+  },
+  {
+    "file": "microservices/health-alerts/template.yaml",
+    "stack": "Health-Alert-Stack"
+  },
+  {
+    "file": "microservices/ta-alerts/template.yaml",
+    "stack": "Trusted-Advisor-Alert-Stack"
+  }
+]

--- a/.github/workflows/cfn.yml
+++ b/.github/workflows/cfn.yml
@@ -12,20 +12,39 @@ on:
       - "**.yaml"
       - ".github/workflows/cfn.yml"
 
-env:
-  STACK_NAME: AWS-Shop-Frontend-Stack
-  STACK_FILE: cloudformation.yaml
-
 # Required to use the AWS CLI
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  build:
+  # Read all the CloudFormation files and stack names and create a matrix
+  get-templates:
     runs-on: ubuntu-latest
 
+    outputs:
+      cfn-info: ${{ steps.read-json.outputs.info }}
+
     steps:
+      - uses: actions/checkout@v3
+
+      - id: read-json
+        run: echo "info=$(jq -c . < .github/workflows/cfn-info.json)" >> "$GITHUB_OUTPUT"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: get-templates
+
+    strategy:
+      matrix:
+        cfn-info: ${{ fromJson(needs.get-templates.outputs.cfn-info) }}
+
+    steps:
+      - name: Set Environment Variables
+        run: |
+          echo "STACK_NAME=${{ matrix.cfn-info.stack }}" >> "$GITHUB_ENV"
+          echo "STACK_FILE=${{ matrix.cfn-info.file }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
@@ -56,10 +75,21 @@ jobs:
   # If the tests were successful and we're pushing to main, create/update the stack
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - get-templates
+      - build
     if: github.event_name == 'push'
 
+    strategy:
+      matrix:
+        cfn-info: ${{ fromJson(needs.get-templates.outputs.cfn-info) }}
+
     steps:
+      - name: Set Environment Variables
+        run: |
+          echo "STACK_NAME=${{ matrix.cfn-info.stack }}" >> "$GITHUB_ENV"
+          echo "STACK_FILE=${{ matrix.cfn-info.file }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials

--- a/detect-cfn-drift.sh
+++ b/detect-cfn-drift.sh
@@ -1,3 +1,8 @@
+# Check if the stack exists before proceeding
+if ! aws cloudformation describe-stacks --stack-name $STACK_NAME &> /dev/null ; then
+    echo "Stack $STACK_NAME doesn't exist, skipping..." && exit 0
+fi
+
 # Start stack drift detection
 DRIFT_ID=$(aws cloudformation detect-stack-drift --stack-name $STACK_NAME | jq -r ".StackDriftDetectionId" )
 

--- a/microservices/ta-alerts/template.yaml
+++ b/microservices/ta-alerts/template.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Subscribe to errors and warnings from Trusted Advisor
+Parameters:
+  Email:
+    Type: String
+    Description: The email address that will receive SNS notifications for the TA alerts
+    # Simple regex from https://stackoverflow.com/a/201378
+    AllowedPattern: "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+Resources:
+  EventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: USEast1AdvisorRule
+      Description: Push Trusted Advisor notifications to an SNS topic
+      EventPattern:
+        source:
+          - aws.trustedadvisor
+        detail-type:
+          - Trusted Advisor Check Item Refresh Notification
+        detail:
+          status:
+            - ERROR
+            - WARN
+      State: ENABLED
+      Targets:
+        - Id: EmailTarget
+          Arn: !Ref SNSTopic
+  SNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      # Encrypt using the default SNS SSE key
+      # Key aliases: aws kms list-aliases
+      KmsMasterKeyId: alias/aws/sns
+      Subscription:
+        - Endpoint: !Ref Email
+          Protocol: email
+      TopicName: TrustedAdvisorNotifications
+  SNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          # Allow EventBridge to send email alerts using SNS
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref SNSTopic
+      Topics:
+        - !Ref SNSTopic


### PR DESCRIPTION
Similar to AWS Health, we can get notified whenever a Trusted Advisor check shows a warning or error status. I also modified the CloudFormation workflow so it should run all the CloudFormation templates that aren't SAM templates, using some JSON trickery.