### PR TITLE
70 apply mozilla observatory fixes to cloudfront distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ Stop build:
 aws codebuild stop-build --id BUILD_ID
 ```
 
+### S3 Commands
+
+List objects:
+
+```bash
+aws s3 ls S3_URI
+```
+
 ### DynamoDB Commands
 
 List tables:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -224,7 +224,7 @@ Resources:
               SSEAlgorithm: AES256
       AccessControl: Private # don't give public access to the S3 bucket directly
       LoggingConfiguration:
-        DestinationBucketName: !Ref LoggingBucket
+        DestinationBucketName: !Ref S3LoggingBucket
         LogFilePrefix: !Ref ReactAppBucketName
       # Some access settings need to be enabled to add bucket policies
       PublicAccessBlockConfiguration:
@@ -273,7 +273,7 @@ Resources:
             Condition:
               Bool:
                 "aws:SecureTransport": false
-  LoggingBucket:
+  S3LoggingBucket:
     Type: AWS::S3::Bucket
     Metadata:
       guard:
@@ -291,12 +291,54 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
       AccessControl: Private
-      # Some access settings need to be enabled to add bucket policies
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
-        BlockPublicPolicy: true # set to false when creating a bucket policy
+        BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: true # set to false when creating a bucket policy
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      # Save money by deleting older copies of objects
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldVersionsRule
+            Status: Enabled
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+      # Enable WORM (write once, read many)
+      ObjectLockEnabled: true
+      ObjectLockConfiguration:
+        ObjectLockEnabled: Enabled
+        Rule:
+          DefaultRetention:
+            Mode: GOVERNANCE # more lax than compliance mode
+            Days: 30
+  CloudFrontLoggingBucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      guard:
+        SuppressedRules:
+          # Reliability suppressions
+          - S3_BUCKET_REPLICATION_ENABLED # stay within 435 MB
+          # Security suppressions
+          - S3_BUCKET_LOGGING_ENABLED # this is a logging bucket
+    # Can't delete an S3 bucket until all its objects are deleted
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      # ACLs must be enabled for CloudFront logs
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
       # Save money by deleting older copies of objects
@@ -338,11 +380,14 @@ Resources:
           CachePolicyId: !Ref CloudFrontCachePolicy
           ViewerProtocolPolicy: redirect-to-https
         PriceClass: PriceClass_100 # only use edge locations in North America, Europe, and Israel
-        # CustomErrorResponses:
-        #   - ErrorCachingMinTTL: 300 # 5 minutes
-        #     ErrorCode: 403
-        #     ResponseCode: 404
-        #     ResponsePagePath: error.html
+        CustomErrorResponses:
+          - ErrorCachingMinTTL: 300 # 5 minutes
+            ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /index.html
+        Logging:
+          Bucket: !GetAtt CloudFrontLoggingBucket.DomainName
+          IncludeCookies: false
   CloudFrontOriginAccessControl:
     Type: AWS::CloudFront::OriginAccessControl
     Properties:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -8,7 +8,15 @@ Parameters:
     Description: The name of the S3 bucket to store the React code
     Default: aws-shop-bucket-jlkafn93hvo0a3f
 #Rules
-#Mappings
+Mappings:
+  CloudFront:
+    # Managed policies from: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
+    ResponseHeadersPolicies:
+      CORSAndSecurityHeadersPolicy: e61eb60c-9c35-4d20-a928-2b84e02af89c
+      CORSWithPreflight: 5cc3b908-e619-4b99-88e5-2cf7f45965bd
+      CORSWithPreflightAndSecurityHeadersPolicy: eaab4381-ed33-4a86-88ca-d9558dc6cd63
+      SecurityHeadersPolicy: 67f7725c-6f97-4210-82d7-5512b31e9d03
+      SimpleCORS: 60669652-455b-4ae9-85a4-c4c02393f86c
 #Conditions
 #Transform
 Resources:
@@ -379,9 +387,18 @@ Resources:
           TargetOriginId: ReactAppS3Origin
           CachePolicyId: !Ref CloudFrontCachePolicy
           ViewerProtocolPolicy: redirect-to-https
+          # Add the necessary security headers to pass Mozilla Observatory
+          # Missing Content-Security-Policy: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+          ResponseHeadersPolicyId:
+            !FindInMap [
+              CloudFront,
+              ResponseHeadersPolicies,
+              SecurityHeadersPolicy,
+            ]
         PriceClass: PriceClass_100 # only use edge locations in North America, Europe, and Israel
         CustomErrorResponses:
           - ErrorCachingMinTTL: 300 # 5 minutes
+            # Redirect 403 errors (forbidden) to a 404 page (not found)
             ErrorCode: 403
             ResponseCode: 404
             ResponsePagePath: /index.html

--- a/microservices/health-alerts/template.yaml
+++ b/microservices/health-alerts/template.yaml
@@ -41,8 +41,9 @@ Resources:
         - Id: EmailTarget
           Arn: !Ref SNSTopic
           # Failed events are retried up to 185 times within 24 hours by default
-          DeadLetterConfig:
-            Arn: !GetAtt DLQ.Arn
+          # This causes false drift detection :(
+          # DeadLetterConfig:
+          #   Arn: !GetAtt DLQ.Arn
   SNSTopic:
     Type: AWS::SNS::Topic
     Properties:

--- a/microservices/ta-alerts/template.yaml
+++ b/microservices/ta-alerts/template.yaml
@@ -26,8 +26,9 @@ Resources:
         - Id: EmailTarget
           Arn: !Ref SNSTopic
           # Failed events are retried up to 185 times within 24 hours by default
-          DeadLetterConfig:
-            Arn: !GetAtt DLQ.Arn
+          # This causes false drift detection :(
+          # DeadLetterConfig:
+          #   Arn: !GetAtt DLQ.Arn
   SNSTopic:
     Type: AWS::SNS::Topic
     Properties:


### PR DESCRIPTION
<img width="845" alt="image" src="https://github.com/Abhiek187/aws-shop/assets/29958092/c53d2ec5-b8b2-4f82-aac9-e8b7ee6fd0a4">

I made the following enhancements to CloudFront:
- **Response header policy:** To get a higher grade for HTTP security in Mozilla Observatory, I used a managed security policy from AWS to add the `Strict-Transport-Security`, `X-XSS-Protection`, `X-Content-Type-Options`, `Referrer-Policy`, and `X-Frame-Options` response headers to the origin. The only header the policy didn't set was Content-Security-Policy. I could add this myself, but then I would need to create my own policy. Instead of adding more lines of code, I thought this would be a good opportunity to take advantage of mappings in CloudFormation to map a policy with its ID.
- **Custom error response:** If the user visits an invalid page, I configured the website to convert the 403 error into a 404 error. I plan to create a custom error page once I integrate react-router, so for now, I redirected errors back to index.html. This will cause the same page to load, but a 404 error will appear in the logs.
- **Logging:** I created an S3 bucket to record the logs whenever people visit the website. These logs include similar information to what you would find in the Network tab. I couldn't use the same bucket for S3 access logs since this bucket required enabling ACLs (despite AWS's security recommendations). But I was still able to apply enough settings, so `cfn-guard` should still be satisfied. 