### PR TITLE
282 add smoother transitions when filtering cards

### DIFF
--- a/shop-app/package-lock.json
+++ b/shop-app/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.16.0",
+        "react-transition-group": "^4.4.5",
         "use-debounce": "^9.0.4"
       },
       "devDependencies": {

--- a/shop-app/package.json
+++ b/shop-app/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.16.0",
+    "react-transition-group": "^4.4.5",
     "use-debounce": "^9.0.4"
   },
   "devDependencies": {

--- a/shop-app/src/components/app-bar/TopBar.tsx
+++ b/shop-app/src/components/app-bar/TopBar.tsx
@@ -1,10 +1,11 @@
-import { AccountCircle } from "@mui/icons-material";
-import AccountCircleIcon from "@mui/icons-material/AccountCircle";
-import CloseIcon from "@mui/icons-material/Close";
-import FilterListIcon from "@mui/icons-material/FilterList";
-import MoreIcon from "@mui/icons-material/MoreVert";
-import SearchIcon from "@mui/icons-material/Search";
-import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+import {
+  AccountCircle,
+  Close,
+  FilterList,
+  MoreVert,
+  Search,
+  ShoppingCart,
+} from "@mui/icons-material";
 import {
   Box,
   Toolbar,
@@ -24,7 +25,7 @@ import { ChangeEvent, MouseEvent, Ref, forwardRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import FilterFields from "./FilterFields";
 
-const Search = styled("div")(({ theme }) => ({
+const SearchWrapper = styled("div")(({ theme }) => ({
   position: "relative",
   borderRadius: theme.shape.borderRadius,
   backgroundColor: alpha(theme.palette.common.white, 0.15),
@@ -172,7 +173,7 @@ const TopBar = () => {
             onClick={handleFilterClose}
             aria-label="close"
           >
-            <CloseIcon />
+            <Close />
           </IconButton>
           <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
             Search
@@ -213,7 +214,7 @@ const TopBar = () => {
     >
       <MenuItem>
         <IconButton size="large" color="inherit">
-          <ShoppingCartIcon />
+          <ShoppingCart />
         </IconButton>
         <p>Open Cart</p>
       </MenuItem>
@@ -244,9 +245,9 @@ const TopBar = () => {
           >
             AWS Shop
           </Typography>
-          <Search>
+          <SearchWrapper>
             <SearchIconWrapper>
-              <SearchIcon />
+              <Search />
             </SearchIconWrapper>
             <StyledInputBase
               placeholder="Search…"
@@ -257,11 +258,11 @@ const TopBar = () => {
               value={query}
               onChange={onChangeQuery}
             />
-          </Search>
+          </SearchWrapper>
           {/* Show the other menu buttons on large screens */}
           <Box sx={{ display: { xs: "none", md: "flex" } }}>
             <IconButton size="large" aria-label="open cart" color="inherit">
-              <ShoppingCartIcon />
+              <ShoppingCart />
             </IconButton>
             <IconButton
               size="large"
@@ -272,7 +273,7 @@ const TopBar = () => {
               onClick={handleProfileMenuOpen}
               color="inherit"
             >
-              <AccountCircleIcon />
+              <AccountCircle />
             </IconButton>
           </Box>
           {/* On small screens, show a filter and triple dot icon */}
@@ -283,7 +284,7 @@ const TopBar = () => {
               onClick={handleFilterOpen}
               color="inherit"
             >
-              <FilterListIcon />
+              <FilterList />
             </IconButton>
             <IconButton
               size="large"
@@ -293,7 +294,7 @@ const TopBar = () => {
               onClick={handleMobileMenuOpen}
               color="inherit"
             >
-              <MoreIcon />
+              <MoreVert />
             </IconButton>
           </Box>
         </Toolbar>

--- a/shop-app/src/components/store/ServiceCard.tsx
+++ b/shop-app/src/components/store/ServiceCard.tsx
@@ -1,3 +1,4 @@
+import { AutoAwesome } from "@mui/icons-material";
 import {
   Button,
   Card,
@@ -6,7 +7,6 @@ import {
   Divider,
   Typography,
 } from "@mui/material";
-import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import { yellow } from "@mui/material/colors";
 import pluralize from "pluralize";
 import React from "react";
@@ -44,7 +44,7 @@ const ServiceCard: React.FC<ServiceProps> = ({ service }) => {
         <>
           <Divider />
           <CardActions>
-            <AutoAwesomeIcon sx={{ color: yellow[700], mr: 1.5 }} />
+            <AutoAwesome sx={{ color: yellow[700], mr: 1.5 }} />
             <Typography variant="caption">
               {`Free Tier: ${commaFormat(service.FreeTier)} ${pluralize(
                 service.Unit,

--- a/shop-app/src/components/store/Store.tsx
+++ b/shop-app/src/components/store/Store.tsx
@@ -1,5 +1,7 @@
-import { CircularProgress, Grid } from "@mui/material";
+import { CircularProgress, Grow, Unstable_Grid2 } from "@mui/material";
+import { Fragment } from "react";
 import { useSearchParams } from "react-router-dom";
+import { TransitionGroup } from "react-transition-group";
 import { useDebounce } from "use-debounce";
 
 import ServiceCard from "./ServiceCard";
@@ -25,17 +27,25 @@ const Store = () => {
     return <p className="text-red-500">{createErrorString(error)}</p>;
   } else {
     return (
-      <Grid
+      // Each card takes up 4 columns
+      <Unstable_Grid2
         container
         spacing={{ xs: 2, md: 3 }}
         columns={{ xs: 4, sm: 8, md: 12 }}
       >
-        {services?.map((service) => (
-          <Grid item xs={4} key={service.Id}>
-            <ServiceCard service={service} />
-          </Grid>
-        ))}
-      </Grid>
+        {/* TransitionGroup is needed to animate items disappearing */}
+        {/* Don't add an extra div to the grid */}
+        <TransitionGroup component={Fragment}>
+          {services?.map((service) => (
+            // Show a smooth transition when cards appear or disappear
+            <Grow key={service.Id}>
+              <Unstable_Grid2 xs={4}>
+                <ServiceCard service={service} />
+              </Unstable_Grid2>
+            </Grow>
+          ))}
+        </TransitionGroup>
+      </Unstable_Grid2>
     );
   }
 };


### PR DESCRIPTION
![AnimationAfter](https://github.com/Abhiek187/aws-shop/assets/29958092/db0c6346-12fe-4818-b307-900a8d8327ee)

I used Material UI's Grow animation to smoothen the card transitions when they're being filtered. I had to wrap the grid around a `TransitionGroup` and tweak some properties to get the transitions working whenever the cards appear and disappear.