### PR TITLE
Switch to a Lambda compute type & Node 20

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: 20
   pre_build:
     commands:
       - cd shop-app # the shell instance is saved every build command

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -199,7 +199,7 @@ Resources:
         # Make sure the image supports the runtime in the buildspec:
         # https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html
         Type: ARM_LAMBDA_CONTAINER
-        Image: aws/codebuild/amazonlinux-aarch64-lambda-standard:nodejs20 # Amazon Linux 2 ARM image
+        Image: aws/codebuild/amazonlinux-aarch64-lambda-standard:nodejs20 # Amazon Linux 2023 ARM image
         ComputeType: BUILD_LAMBDA_1GB # free tier eligible
         EnvironmentVariables:
           - Name: CI

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -198,9 +198,9 @@ Resources:
       Environment:
         # Make sure the image supports the runtime in the buildspec:
         # https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html
-        Type: ARM_CONTAINER
-        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0 # Amazon Linux 2 ARM image
-        ComputeType: BUILD_GENERAL1_SMALL # free tier eligible
+        Type: ARM_LAMBDA_CONTAINER
+        Image: aws/codebuild/amazonlinux-aarch64-lambda-standard:nodejs20 # Amazon Linux 2 ARM image
+        ComputeType: BUILD_LAMBDA_1GB # free tier eligible
         EnvironmentVariables:
           - Name: CI
             Value: "true"

--- a/microservices/store/aws-services.json
+++ b/microservices/store/aws-services.json
@@ -88,7 +88,7 @@
   {
     "Name": "CodeBuild",
     "Description": "CI (Continuous Integration): build and test your code",
-    "Price": 0.01,
+    "Price": 6e-4,
     "Unit": "build minute",
     "Category": "free",
     "FreeTier": 100


### PR DESCRIPTION
CodeBuild offers Lambda compute types now. We were previously using on-demand EC2 compute types. The free tier is the same (100 build minutes), but cheaper beyond the free tier (16m to 1₵ compared to 3m to 1₵). We'll have less memory than before (1 GB compared to 3 GB), so that might cause builds to be slower. But, AWS claims Lambda has faster start times, so I want to compare the build times to see if this is worth it. Also, Lambda apparently doesn't support badges or custom timeouts, so hopefully a build doesn't hang!