### PR TITLE
Cognito Pt 2: View & Delete Passkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,18 @@ aws cognito-idp admin-disable-user --user-pool-id ID --username USERNAME
 aws cognito-idp admin-delete-user --user-pool-id ID --username USERNAME
 ```
 
+Get WebAuthn Credentials:
+
+```bash
+aws cognito-idp list-web-authn-credentials --access-token ACCESS_TOKEN
+```
+
+Delete WebAuthn Credentials:
+
+```bash
+aws cognito-idp delete-web-authn-credential --access-token ACCESS_TOKEN --credential-id CREDENTIAL_ID
+```
+
 ### Pinpoint Commands
 
 Publish event:

--- a/shop-app/src/components/app-bar/TopBar.tsx
+++ b/shop-app/src/components/app-bar/TopBar.tsx
@@ -248,32 +248,30 @@ const TopBar = () => {
   };
 
   const handleDeleteAccount = async () => {
-    // Dynamically import the AWS SDK to improve the build size
-    const { CognitoIdentityProvider } = await import(
+    // Dynamically import the AWS SDK to reduce the build size
+    const { CognitoIdentityProviderClient, DeleteUserCommand } = await import(
       "@aws-sdk/client-cognito-identity-provider"
     );
-    const cognito = new CognitoIdentityProvider({
+    const cognito = new CognitoIdentityProviderClient({
       region: Constants.Cognito.REGION,
     });
+    const deleteUserCommand = new DeleteUserCommand({
+      AccessToken: oauth.accessToken,
+    });
 
-    cognito.deleteUser(
-      {
-        AccessToken: oauth.accessToken,
-      },
-      (error, data) => {
-        if (error !== null) {
-          console.error("Delete error:", error);
-          setDeleteSuccess(false);
-        } else {
-          console.log("Delete success:", data);
-          setDeleteSuccess(true);
-          void handleSignOut();
-          handleCloseAccountDialog();
-        }
+    try {
+      const data = await cognito.send(deleteUserCommand);
+      console.log("Delete success:", data);
 
-        setShowDeleteAlert(true);
-      }
-    );
+      setDeleteSuccess(true);
+      void handleSignOut();
+      handleCloseAccountDialog();
+    } catch (error) {
+      console.error("Delete error:", error);
+      setDeleteSuccess(false);
+    } finally {
+      setShowDeleteAlert(true);
+    }
   };
 
   const handleMobileMenuOpen = (event: MouseEvent<HTMLElement>) => {

--- a/shop-app/src/components/profile/DeletePasskeyDialog.test.tsx
+++ b/shop-app/src/components/profile/DeletePasskeyDialog.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import DeletePasskeyDialog from "./DeletePasskeyDialog";
+
+describe("DeletePasskeyDialog", () => {
+  it("should render", () => {
+    const name = "Windows Hello";
+    const mockOnClose = vi.fn();
+    const mockOnDelete = vi.fn();
+
+    render(
+      <DeletePasskeyDialog
+        open
+        name={name}
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+      />
+    );
+
+    const cancelButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: /cancel/i,
+    });
+    const deleteButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: /delete/i,
+    });
+    expect(cancelButton).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(cancelButton);
+    expect(mockOnClose).toHaveBeenCalled();
+    fireEvent.click(deleteButton);
+    expect(mockOnDelete).toHaveBeenCalled();
+  });
+});

--- a/shop-app/src/components/profile/DeletePasskeyDialog.tsx
+++ b/shop-app/src/components/profile/DeletePasskeyDialog.tsx
@@ -1,0 +1,41 @@
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from "@mui/material";
+
+type DeletePasskeyDialogProps = {
+  open: boolean;
+  name: string;
+  onClose: () => void;
+  onDelete: () => void;
+};
+
+const DeletePasskeyDialog = ({
+  open,
+  name,
+  onClose,
+  onDelete,
+}: Readonly<DeletePasskeyDialogProps>) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Delete Passkey</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Are you sure you want to delete this passkey? {name}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button color="error" onClick={onDelete}>
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeletePasskeyDialog;

--- a/shop-app/src/components/profile/Profile.tsx
+++ b/shop-app/src/components/profile/Profile.tsx
@@ -3,6 +3,9 @@ import { Cancel, CheckCircle, Close, Delete } from "@mui/icons-material";
 import {
   Box,
   IconButton,
+  List,
+  ListItem,
+  ListItemText,
   Table,
   TableBody,
   TableCell,
@@ -60,8 +63,11 @@ const Profile = () => {
   }, []);
 
   useEffect(() => {
-    void fetchPasskeys();
-  }, []);
+    // Fetch passkeys if signed in
+    if (oauth.accessToken.length > 0) {
+      void fetchPasskeys();
+    }
+  }, [oauth.accessToken]);
 
   const handleCloseProfile = useCallback(() => {
     void navigate(-1);
@@ -155,28 +161,43 @@ const Profile = () => {
                 </TableCell>
               )}
             </TableRow>
+            <TableRow>
+              <TableCell>
+                <strong>Passkeys</strong>
+              </TableCell>
+              <TableCell>
+                {credentials.length === 0 ? (
+                  "—"
+                ) : (
+                  <List>
+                    {credentials.map((credential) => (
+                      <ListItem
+                        key={credential.CredentialId}
+                        secondaryAction={
+                          <IconButton
+                            color="error"
+                            edge="end"
+                            onClick={() =>
+                              void handleDeletePasskey(credential.CredentialId)
+                            }
+                            aria-label={`Delete passkey ${credential.FriendlyCredentialName}`}
+                          >
+                            <Delete />
+                          </IconButton>
+                        }
+                      >
+                        <ListItemText
+                          primary={credential.FriendlyCredentialName}
+                          secondary={`Created at: ${credential.CreatedAt?.toLocaleDateString()}`}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
+                )}
+              </TableCell>
+            </TableRow>
           </TableBody>
         </Table>
-        <Typography variant="h4">Passkeys</Typography>
-        <ul>
-          {credentials.map((credential) => (
-            <li key={credential.CredentialId} className="flex gap-3">
-              <p>{credential.FriendlyCredentialName}</p>
-              <p className="italic">
-                Created at: {credential.CreatedAt?.toLocaleDateString()}
-              </p>
-              <IconButton
-                color="error"
-                onClick={() =>
-                  void handleDeletePasskey(credential.CredentialId)
-                }
-                aria-label={`Delete passkey ${credential.FriendlyCredentialName}`}
-              >
-                <Delete />
-              </IconButton>
-            </li>
-          ))}
-        </ul>
       </main>
     </>
   );

--- a/shop-app/src/components/profile/Profile.tsx
+++ b/shop-app/src/components/profile/Profile.tsx
@@ -185,7 +185,7 @@ const Profile = () => {
               <TableCell>
                 <strong>Passkeys</strong>
               </TableCell>
-              <TableCell>
+              <TableCell align="right">
                 {credentials.length === 0 ? (
                   "—"
                 ) : (

--- a/shop-app/src/components/profile/Profile.tsx
+++ b/shop-app/src/components/profile/Profile.tsx
@@ -1,4 +1,5 @@
-import { Cancel, CheckCircle, Close } from "@mui/icons-material";
+import type { WebAuthnCredentialDescription } from "@aws-sdk/client-cognito-identity-provider";
+import { Cancel, CheckCircle, Close, Delete } from "@mui/icons-material";
 import {
   Box,
   IconButton,
@@ -9,17 +10,22 @@ import {
   Typography,
 } from "@mui/material";
 import { visuallyHidden } from "@mui/utils";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { parseJWT } from "../../utils/oauth";
 import { selectApp } from "../../store/appSlice";
 import { IdTokenPayload } from "../../types/TokenPayload";
 import { useAppSelector } from "../../store/hooks";
+import { Constants } from "../../utils/constants";
 
 const Profile = () => {
   const { oauth } = useAppSelector(selectApp);
   const navigate = useNavigate();
+
+  const [credentials, setCredentials] = useState<
+    WebAuthnCredentialDescription[]
+  >([]);
 
   const [, idTokenPayload] = parseJWT<IdTokenPayload>(oauth.idToken);
 
@@ -29,6 +35,33 @@ const Profile = () => {
       void navigate("/", { replace: true });
     }
   }, [idTokenPayload, navigate]);
+
+  const fetchPasskeys = useCallback(async () => {
+    const { CognitoIdentityProvider } = await import(
+      "@aws-sdk/client-cognito-identity-provider"
+    );
+    const cognito = new CognitoIdentityProvider({
+      region: Constants.Cognito.REGION,
+    });
+
+    cognito.listWebAuthnCredentials(
+      {
+        AccessToken: oauth.accessToken,
+      },
+      (error, data) => {
+        if (error !== null) {
+          console.error("List passkeys error:", error);
+        } else {
+          console.log("List passkeys success:", data);
+          setCredentials(data?.Credentials ?? []);
+        }
+      }
+    );
+  }, []);
+
+  useEffect(() => {
+    void fetchPasskeys();
+  }, []);
 
   const handleCloseProfile = useCallback(() => {
     void navigate(-1);
@@ -44,6 +77,32 @@ const Profile = () => {
     window.addEventListener("keyup", handleKeyUp);
     return () => window.removeEventListener("keyup", handleKeyUp);
   }, [handleCloseProfile]);
+
+  const handleDeletePasskey = async (credentialId?: string) => {
+    const { CognitoIdentityProvider } = await import(
+      "@aws-sdk/client-cognito-identity-provider"
+    );
+    const cognito = new CognitoIdentityProvider({
+      region: Constants.Cognito.REGION,
+    });
+
+    cognito.deleteWebAuthnCredential(
+      {
+        AccessToken: oauth.accessToken,
+        CredentialId: credentialId,
+      },
+      (error, data) => {
+        if (error !== null) {
+          console.error("Delete passkey error:", error);
+        } else {
+          console.log("Delete passkey success:", data);
+          setCredentials((creds) =>
+            creds.filter((cred) => cred.CredentialId !== credentialId)
+          );
+        }
+      }
+    );
+  };
 
   return (
     <>
@@ -98,6 +157,26 @@ const Profile = () => {
             </TableRow>
           </TableBody>
         </Table>
+        <Typography variant="h4">Passkeys</Typography>
+        <ul>
+          {credentials.map((credential) => (
+            <li key={credential.CredentialId} className="flex gap-3">
+              <p>{credential.FriendlyCredentialName}</p>
+              <p className="italic">
+                Created at: {credential.CreatedAt?.toLocaleDateString()}
+              </p>
+              <IconButton
+                color="error"
+                onClick={() =>
+                  void handleDeletePasskey(credential.CredentialId)
+                }
+                aria-label={`Delete passkey ${credential.FriendlyCredentialName}`}
+              >
+                <Delete />
+              </IconButton>
+            </li>
+          ))}
+        </ul>
       </main>
     </>
   );

--- a/shop-app/src/components/profile/Profile.tsx
+++ b/shop-app/src/components/profile/Profile.tsx
@@ -59,6 +59,7 @@ const Profile = () => {
 
     try {
       const data = await cognito.send(listPasskeysCommand);
+      console.log("List passkeys success:", data);
       setCredentials(data.Credentials ?? []);
     } catch (error) {
       console.error("List passkeys error:", error);


### PR DESCRIPTION
<img width="547" alt="profile-passkeys" src="https://github.com/user-attachments/assets/fced028a-a0c3-40d3-b6e3-80a64460f610" />

<img width="431" alt="passkey-delete" src="https://github.com/user-attachments/assets/e1146056-ee8e-4649-93dd-53daf92e694b" />

I added the ability for users to view all their passkeys and delete them using the provided Cognito APIs. Like `deleteUser`, these accept an access token, so they can be called from the UI. I also updated all the AWS SDK calls to use the v3 syntax since the v2 syntax may be removed in the future. It should also reduce the chunked build, which I can verify after the pipeline runs. (**Edit:** Yes by 40%!)

| File | Before | After |
| - | - | - |
| dist/index.html | 0.83 kB (gzip: 0.46 kB) | 0.83 kB (gzip: 0.46 kB)
| dist/assets/index-D5ey3eXh.css | 4.21 kB (gzip: 0.98 kB) | 4.21 kB (gzip: 0.98 kB)
| dist/assets/index-kgNJyU0a.js | 218.07 kB (gzip: 47.44 kB) | 132.88 kB (gzip: 38.33 kB)
| dist/assets/index-Cwe2l710.js | 571.55 kB (gzip: 184.13 kB) | 579.95 kB (gzip: 186.08 kB)

The only thing about deleting passkeys is that they're only deleted from Cognito, but users would need to manually delete passkeys from their password manager as well. I'm not sure if there's a way to programmatically delete the passkey, unless there's a standard API that signals the password managers to delete their passkeys.