### PR TITLE
Add the AppManagerCFNStackKey tag to each stack

### DIFF
--- a/.github/workflows/cfn-info.json
+++ b/.github/workflows/cfn-info.json
@@ -2,16 +2,19 @@
   {
     "file": "cloudformation.yaml",
     "stack": "AWS-Shop-Frontend-Stack",
-    "params": "params.json"
+    "params": "params.json",
+    "tags": "tags.json"
   },
   {
     "file": "microservices/health-alerts/template.yaml",
     "stack": "Health-Alert-Stack",
-    "params": "microservices/health-alerts/params.json"
+    "params": "microservices/health-alerts/params.json",
+    "tags": "microservices/health-alerts/tags.json"
   },
   {
     "file": "microservices/ta-alerts/template.yaml",
     "stack": "Trusted-Advisor-Alert-Stack",
-    "params": "microservices/ta-alerts/params.json"
+    "params": "microservices/ta-alerts/params.json",
+    "tags": "microservices/ta-alerts/tags.json"
   }
 ]

--- a/.github/workflows/cfn.yml
+++ b/.github/workflows/cfn.yml
@@ -90,6 +90,7 @@ jobs:
           echo "STACK_NAME=${{ matrix.cfn-info.stack }}" >> "$GITHUB_ENV"
           echo "STACK_FILE=${{ matrix.cfn-info.file }}" >> "$GITHUB_ENV"
           echo "PARAM_FILE=${{ matrix.cfn-info.params }}" >> "$GITHUB_ENV"
+          echo "TAGS_FILE=${{ matrix.cfn-info.tags }}" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
 
@@ -105,5 +106,6 @@ jobs:
           name: ${{ env.STACK_NAME }}
           template: ${{ env.STACK_FILE }}
           parameter-overrides: file://${{ github.workspace }}/${{ env.PARAM_FILE }}
+          tags: file://${{ github.workspace }}/${{ env.TAGS_FILE }}
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Download the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-
 Create stack:
 
 ```bash
-aws cloudformation create-stack --stack-name NAME --template-body FILE_PATH --parameters ParameterKey=KEY,ParameterValue=VALUE --capabilities CAPABILITY_NAMED_IAM
+aws cloudformation create-stack --stack-name NAME --template-body FILE_PATH --parameters ParameterKey=KEY,ParameterValue=VALUE --tags TAGS_FILE_PATH --capabilities CAPABILITY_NAMED_IAM
 ```
 
 List stacks:
@@ -173,7 +173,7 @@ aws cloudformation describe-stacks # more detailed than list-stacks
 Update stack:
 
 ```bash
-aws cloudformation update-stack --stack-name NAME --template-body FILE_PATH --parameters PARAM_FILE_PATH --capabilities CAPABILITY_NAMED_IAM
+aws cloudformation update-stack --stack-name NAME --template-body FILE_PATH --parameters PARAM_FILE_PATH --tags TAGS_FILE_PATH --capabilities CAPABILITY_NAMED_IAM
 ```
 
 Continue update rollback:
@@ -209,7 +209,7 @@ aws cloudformation describe-stack-drift-detection-status --stack-drift-detection
 Create change set:
 
 ```bash
-aws cloudformation create-change-set --stack-name NAME --change-set-name CHANGE_SET --template-body FILE_PATH --parameters PARAM_FILE_PATH --capabilities CAPABILITY_NAMED_IAM
+aws cloudformation create-change-set --stack-name NAME --change-set-name CHANGE_SET --template-body FILE_PATH --parameters PARAM_FILE_PATH --tags TAGS_FILE_PATH --capabilities CAPABILITY_NAMED_IAM
 ```
 
 List change sets:

--- a/microservices/health-alerts/tags.json
+++ b/microservices/health-alerts/tags.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Key": "AppManagerCFNStackKey",
+    "Value": "arn:aws:cloudformation:us-east-1:701157632481:stack/Health-Alert-Stack/f035cfc0-162a-11ee-a14e-12f8f4f0e2d3"
+  }
+]

--- a/microservices/iam-old/samconfig.toml
+++ b/microservices/iam-old/samconfig.toml
@@ -8,3 +8,4 @@ confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
 image_repositories = []
 parameter_overrides = "ParameterKey=Email,UsePreviousValue=true"
+tags = "AppManagerCFNStackKey=arn:aws:cloudformation:us-east-1:701157632481:stack/IAM-Old-Stack/0cd4a990-f910-11ed-86c8-0ec36529a8bd"

--- a/microservices/log-retention/samconfig.toml
+++ b/microservices/log-retention/samconfig.toml
@@ -7,3 +7,4 @@ region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
 image_repositories = []
+tags = "AppManagerCFNStackKey=arn:aws:cloudformation:us-east-1:701157632481:stack/Log-Retention-Stack/73567930-8dc7-11ef-a242-12ceca569401"

--- a/microservices/store/samconfig.toml
+++ b/microservices/store/samconfig.toml
@@ -19,6 +19,7 @@ s3_prefix = "AWS-Shop-Store-Service"
 region = "us-east-1"
 image_repositories = []
 parameter_overrides = "ParameterKey=Email,UsePreviousValue=true"
+tags = "AppManagerCFNStackKey=arn:aws:cloudformation:us-east-1:701157632481:stack/AWS-Shop-Store-Service/8d082c90-f2bc-11ed-aca7-0e17106275ff"
 
 [default.package.parameters]
 resolve_s3 = true

--- a/microservices/ta-alerts/tags.json
+++ b/microservices/ta-alerts/tags.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Key": "AppManagerCFNStackKey",
+    "Value": "arn:aws:cloudformation:us-east-1:701157632481:stack/Trusted-Advisor-Alert-Stack/fe034dd0-2061-11ee-a60a-1210e009b02f"
+  }
+]

--- a/tags.json
+++ b/tags.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Key": "AppManagerCFNStackKey",
+    "Value": "arn:aws:cloudformation:us-east-1:701157632481:stack/AWS-Shop-Frontend-Stack/95097020-d57f-11ed-9c56-0e1d4b60fc0b"
+  }
+]


### PR DESCRIPTION
This will allow us to group costs on a stack level using App Manager (which is free 😁). I had to hardcode all the ARNs since I can't reference "AWS::StackId" from an external tags file, nor can I specify tags for all resources within a CloudFormation template without listing them for every resource.